### PR TITLE
shorter name for 'unsupported' GPUs and rounded GPU voltage

### DIFF
--- a/src/constants/gpu_constants.py
+++ b/src/constants/gpu_constants.py
@@ -9,6 +9,10 @@ GPU_VOLT = 'GPU Voltage'
 
 DYNAMIC_GPU_PROPERTIES = [TEMP, GPU_FREQ, MEM_FREQ, VRAM_USAGE, GPU_VOLT]
 
-UNSUPPORTED_GPU_MODELS = [
-    'Radeon Vega Series / Radeon Vega Mobile Series'
-]
+UNKNOWN_MODEL = 'Unknown model'
+
+REGEX_MODEL_WITH_MODEL_IN_BRACKETS_MATCH = r"Advanced\sMicro\sDevices,\sInc\..\[AMD\/ATI\]\s[a-zA-Z0-9\/\s]+\s\[[a-zA-Z0-9\s\/]+\]"
+REGEX_MODEL_WITH_MODEL_IN_BRACKETS_FINDALL = r"\s\[[a-zA-Z0-9\s\/]+\]"
+
+REGEX_MODEL_ONLY_SERIES_NAME_MATCH = r"Advanced\sMicro\sDevices,\sInc\..\[AMD\/ATI\]\s[a-zA-Z0-9\s\/]+\s\([a-zA-Z0-9\s\/]+\)"
+REGEX_MODEL_ONLY_SERIES_NAME_FINDALL = r"\s[a-zA-Z0-9\s\/]+\s"

--- a/src/constants/gpu_constants.py
+++ b/src/constants/gpu_constants.py
@@ -8,3 +8,7 @@ PCI_SLOT = 'PCI Slot'
 GPU_VOLT = 'GPU Voltage'
 
 DYNAMIC_GPU_PROPERTIES = [TEMP, GPU_FREQ, MEM_FREQ, VRAM_USAGE, GPU_VOLT]
+
+UNSUPPORTED_GPU_MODELS = [
+    'Radeon Vega Series / Radeon Vega Mobile Series'
+]

--- a/src/services/gpu_service.py
+++ b/src/services/gpu_service.py
@@ -1,6 +1,8 @@
 import pyamdgpuinfo
 import subprocess
 
+import numpy as np
+
 from constants.gpu_constants import UNSUPPORTED_GPU_MODELS
 
 class GpuService:

--- a/src/services/gpu_service.py
+++ b/src/services/gpu_service.py
@@ -58,7 +58,8 @@ class GpuService:
 
     def get_gpu_voltage(self) -> str:
         try:
-            return '{} V'.format(pyamdgpuinfo.get_gpu(self.index).query_graphics_voltage())
+            voltage = pyamdgpuinfo.get_gpu(self.index).query_graphics_voltage()
+            return '{} V'.format(round(voltage, 3))
         except:
             return '0 V'
 

--- a/src/services/gpu_service.py
+++ b/src/services/gpu_service.py
@@ -27,10 +27,10 @@ class GpuService:
             slot = pyamdgpuinfo.get_gpu(self.index).pci_slot[5:]
             model= subprocess.getstatusoutput("lspci | grep -i "+slot+" | cut -d ':' -f3")[1]
 
-            for unsupported_model in UNSUPPORTED_GPU_MODELS:
-                if unsupported_model in model:
-                    model = unsupported_model
-                    break
+            try:
+                model = next(x for x in UNSUPPORTED_GPU_MODELS if x in model)
+            except Exception as e:
+                print(e)
 
             return model
 

--- a/src/services/gpu_service.py
+++ b/src/services/gpu_service.py
@@ -1,8 +1,6 @@
 import pyamdgpuinfo
 import subprocess
 
-import numpy as np
-
 from constants.gpu_constants import UNSUPPORTED_GPU_MODELS
 
 class GpuService:


### PR DESCRIPTION
Now that I have my beloved Slimbook One I have discovered that the GPU model name (for this particular PC) is getting it from the 'lspci' command instead of using the 'pyamdgpuinfo' library. 
Since this name is huge and makes the window very wide I decided to add a sort of listing for these unsupported models. This way it looks a bit nicer.

I have also limited the voltage decimals since values like '0.98000001' were appearing (not exactly, it is an example).


Best regards and thanks!
