### PR TITLE
Fix ryzenadj not compiling on Ubuntu 22.04 based distro

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Depends: ${misc:Depends}, ${python:Depends},
      cmake-data,
      gir1.2-ayatanaappindicator3-0.1,
      libcurl4,
+     libpci-dev,
      mokutil
 Description: Aplicacion para la gestion de rendimiento de procesadores amd
  Aplicacion para la gestion de rendimiento de procesadores amd


### PR DESCRIPTION
Hi, I'm using Drauger OS 7.6 (which is based on Ubuntu Jammy) and slimbookamdcontroller doesn't compile without `libpci-dev` and it seems like it doesn't come pre-installed with my distro.

I wanted to add it here to prevent future ubuntu-based users having problem with this app.

I don't know how debian control templates work, if it's already included with them, please review before merging.