### PR TITLE
Fix pgrep length limit

### DIFF
--- a/bin/slimbookamdcontroller
+++ b/bin/slimbookamdcontroller
@@ -23,7 +23,7 @@ sys.path.insert(1, srcpath)
 
 
 if __name__ == "__main__":
-    pgrep = subprocess.getoutput("pgrep slimbookamdcontroller")
+    pgrep = subprocess.getoutput("pgrep -f slimbookamdcontroller")
 
     numProcRunning = pgrep.split('\n')
 


### PR DESCRIPTION
This fix is related to https://github.com/Slimbook-Team/slimbookbattery/commit/5ec4ab95760a738b690242beb0db0171aab2f3cc.

> This patch makes the program run in Debian and other systems. In them, pgrep has a limit of 15 characters, so the "slimbookbatterypreferences" string is too long for it. This patch uses the -f parameter to fix this.

---

I was working on a rather elaborate fix for this, since I did not know whether pgrep's `-f` option is available across all versions and systems. However, as I was getting ready to make a fork for a PR, I spotted the linked commit on the slimbookbattery repository to address the issue (I am having the exact same issue with that application as well). I also spot `pgrep -f` in other places in this repository, so I suppose the flag was simply forgotten here.

I hope I am not overlooking something, which makes the exclusion of `-f` intentional. Reason for this fix, is that I cannot launch the slimbookamdcontroller myself, even if it is not running (it prints to the terminal that the application is already running) &mdash; only way to launch it is to allow it at startup. After some digging, I found the current pgrep command to spit out an error, which triggers the following `if` conditions wrongly.

*P.S. This is my first every code contribution to a project!*